### PR TITLE
Set upload artifact name

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -27,6 +27,7 @@ jobs:
         python -m build --sdist --outdir sdist
     - uses: actions/upload-artifact@v4
       with: 
+        name: sdist-artifact
         path: ./sdist/*
 
 
@@ -55,6 +56,7 @@ jobs:
         python -m cibuildwheel --output-dir wheelhouse
     - uses: actions/upload-artifact@v4
       with:
+        name: wheel-artifact
         path: ./wheelhouse/*.whl
 
 

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
         with:
-          name: artifact
+          name: sdist-artifact
           path: ./dist/
       - uses: pypa/gh-action-pypi-publish@v1.8.11
         with:


### PR DESCRIPTION
After the update of upload-artifact action to v4.0, it is not allowed anymore to update an artifact file after its creation.